### PR TITLE
mask (bitwise vs element-wise) fixes

### DIFF
--- a/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor.swift
+++ b/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor.swift
@@ -168,6 +168,9 @@ public extension AttentionDescriptor {
     output.blockDimensions = createBlockDimensions()
     output.cacheState = createCacheState()
     output.headDimension = createHeadDimension()
+    if let matrixDimensions {
+      output.sequenceLength = max(matrixDimensions.row, matrixDimensions.column)
+    }
     output.memoryPrecisions = memoryPrecisions
     if MTLContext.global.device.supportsFamily(.apple9) {
       output.preferAsyncCache = true

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+Softmax.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+Softmax.swift
@@ -330,28 +330,21 @@ extension AttentionKernel {
     """
   }
 
-  // Auto-optimization heuristics based on comprehensive benchmarking
+  // Resolve bitmask-vs-element-wise masking. An explicit override (used by
+  // calibration to benchmark both strategies) wins; otherwise the shared,
+  // cached, data-driven heuristic decides — so the kernel and downstream
+  // callers always agree.
   private func shouldUseBitmaskOptimization() -> Bool {
-    // Head dimensions where bitmask consistently performs well
-    let headDim = headDimension
-
-    // Based on benchmark results: head dimensions 64 and 128 show strong bitmask preference
-    if headDim == 64 || headDim == 128 {
+    if let override = maskingStrategyOverride {
+      return override == .bitmask
+    }
+    let head = Int(headDimension)
+    guard let seq = sequenceLength.map(Int.init) else {
       return true
     }
-
-    // For smaller head dimensions, bitmask tends to be better
-    if headDim <= 96 {
-      return true
-    }
-
-    // For very large head dimensions, element-wise tends to be more stable
-    if headDim >= 192 {
-      return false
-    }
-
-    // Default to bitmask for intermediate sizes (good average performance)
-    return true
+    return MaskingStrategyHeuristic.shared.recommend(
+      sequenceLength: seq, headDimension: head
+    ) == .bitmask
   }
 
   private func generateBitmaskMasking() -> String {

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel.swift
@@ -25,6 +25,10 @@ public struct AttentionKernel {
       parallelization: UInt16, traversal: UInt16, head: UInt16
     )
   var headDimension: UInt16
+  /// Sequence length used for the masking-strategy heuristic (nil → head-only).
+  var sequenceLength: UInt32?
+  /// Force a masking strategy, bypassing the heuristic (used by calibration).
+  var maskingStrategyOverride: MaskingStrategy?
   public var threadgroupMemoryAllocation: UInt16
 
   // Scale factor for attention computation
@@ -52,6 +56,8 @@ public struct AttentionKernel {
 
     self.blockDimensions = blockDimensions
     self.headDimension = headDimension
+    sequenceLength = descriptor.sequenceLength
+    maskingStrategyOverride = descriptor.maskingStrategyOverride
 
     // Set scale factor with backward compatibility
     if let customScale = descriptor.softmaxScale {

--- a/Sources/FlashAttention/Attention/AttentionKernelDescriptor.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernelDescriptor.swift
@@ -17,6 +17,16 @@ public struct AttentionKernelDescriptor {
   /// Required. The problem size along the head dimension.
   public var headDimension: UInt16?
 
+  /// The sequence length used for masking-strategy selection
+  /// (`MaskingStrategyHeuristic`). Optional for backward compatibility; when
+  /// nil, the heuristic falls back to a head-only decision.
+  public var sequenceLength: UInt32?
+
+  /// Force a specific masking strategy at codegen time, bypassing the
+  /// heuristic. Used by `MaskingStrategyHeuristic.calibrate` to benchmark both
+  /// strategies for the same shape. `nil` (default) = consult the heuristic.
+  public var maskingStrategyOverride: MaskingStrategy?
+
   public var memoryPrecisions: [AttentionOperand: GEMMOperandPrecision] = [:]
 
   /// Scale factor for attention computation (typically 1/√head_dim).

--- a/Sources/FlashAttention/Attention/MaskingStrategyHeuristic.swift
+++ b/Sources/FlashAttention/Attention/MaskingStrategyHeuristic.swift
@@ -1,0 +1,448 @@
+import Foundation
+@preconcurrency import Metal
+
+/// Masking strategy for applying sparsity patterns (causal, sliding window,
+/// block-sparse) inside the softmax.
+///
+/// `bitmask` precomputes the mask as a small integer bitmask and applies it
+/// with bitwise logic; `elementWise` checks each element's (row, col) against
+/// the sparsity rule directly. Which is faster depends on the problem shape
+/// and the GPU — bitmask has lower arithmetic cost but element-wise avoids
+/// the bitmask setup, and the crossover moves sharply with sequence length.
+public enum MaskingStrategy: String, Codable, Sendable {
+  case elementWise
+  case bitmask
+}
+
+/// Shared, cached, data-driven selector for `MaskingStrategy`.
+///
+/// Both the kernel codegen (`AttentionKernel.shouldUseBitmaskOptimization`)
+/// and downstream callers resolve through `MaskingStrategyHeuristic.shared` so
+/// they always agree.
+///
+/// Resolution order for `recommend`:
+/// 1. In-memory cache (populated by `recordMeasurement`, e.g. from a warm
+///    benchmark on this device).
+/// 2. A fitted default rule (derived from Apple-Silicon benchmarking).
+///
+/// The default rule is a cheap cold-start; call `recordMeasurement` to seed the
+/// cache with measured truths for the shapes you care about. The cache is
+/// keyed by a coarse sequence-length bucket so nearby sizes share a result.
+public final class MaskingStrategyHeuristic: @unchecked Sendable {
+  public static let shared = MaskingStrategyHeuristic()
+
+  private var cache: [ShapeKey: MaskingStrategy] = [:]
+  private let lock = NSLock()
+
+  private struct ShapeKey: Hashable {
+    let sequenceBucket: Int
+    let headDimension: Int
+  }
+
+  /// Bucket a sequence length to a nearby calibrated anchor so that close
+  /// sizes share one decision (and one cache entry).
+  public static func sequenceBucket(_ sequenceLength: Int) -> Int {
+    let anchors = [64, 128, 256, 512, 768, 1024, 1536, 2048, 3072, 4096]
+    var best = anchors[0]
+    var bestDelta = abs(sequenceLength - best)
+    for anchor in anchors.dropFirst() {
+      let delta = abs(sequenceLength - anchor)
+      if delta < bestDelta {
+        best = anchor
+        bestDelta = delta
+      }
+    }
+    return best
+  }
+
+  /// Recommend a masking strategy for the given shape.
+  public func recommend(
+    sequenceLength: Int,
+    headDimension: Int
+  )
+    -> MaskingStrategy
+  {
+    let key = ShapeKey(
+      sequenceBucket: Self.sequenceBucket(sequenceLength),
+      headDimension: headDimension
+    )
+    lock.lock()
+    if let cached = cache[key] {
+      lock.unlock()
+      return cached
+    }
+    let choice = defaultRule(sequenceLength: sequenceLength, headDimension: headDimension)
+    cache[key] = choice
+    lock.unlock()
+    return choice
+  }
+
+  /// Record a measured strategy (e.g. the winner of a warm benchmark) so that
+  /// later `recommend` calls for this shape return it from the cache instead of
+  /// the default rule. Thread-safe.
+  public func recordMeasurement(
+    sequenceLength: Int,
+    headDimension: Int,
+    strategy: MaskingStrategy
+  ) {
+    let key = ShapeKey(
+      sequenceBucket: Self.sequenceBucket(sequenceLength),
+      headDimension: headDimension
+    )
+    lock.lock()
+    cache[key] = strategy
+    lock.unlock()
+  }
+
+  /// Clear the cache (e.g. between benchmark runs to force re-evaluation).
+  public func clearCache() {
+    lock.lock()
+    cache.removeAll()
+    lock.unlock()
+  }
+
+  /// Cold-start default rule, fitted to benchmark data on Apple Silicon.
+  ///
+  /// Key finding: the sequence length is the dominant signal (the previous
+  /// head-only heuristic ignored it). Head 192 consistently favours bitmask;
+  /// very large sequences (≥4096) favour element-wise except at head 192;
+  /// seq≈2048 is a bitmask sweet spot; head 128 only favours bitmask for small
+  /// sequences.
+  private func defaultRule(
+    sequenceLength: Int,
+    headDimension: Int
+  )
+    -> MaskingStrategy
+  {
+    if headDimension == 192 {
+      return .bitmask
+    }
+    if sequenceLength >= 4096 {
+      return .elementWise
+    }
+    if sequenceLength >= 1792, sequenceLength <= 2560 {
+      return .bitmask
+    }
+    if headDimension == 128 {
+      return sequenceLength <= 256 ? .bitmask : .elementWise
+    }
+    if sequenceLength <= 256 {
+      return .bitmask
+    }
+    if headDimension == 256, sequenceLength >= 1024 {
+      return .elementWise
+    }
+    return .bitmask
+  }
+
+  // MARK: - Calibration payload
+
+  /// Hydrate the in-memory cache from a previously-produced (or loaded from
+  /// disk) calibration. Entries override the default rule for their shapes.
+  public func apply(_ calibration: MaskingCalibration) {
+    lock.lock()
+    for entry in calibration.entries {
+      cache[ShapeKey(sequenceBucket: entry.sequenceBucket, headDimension: entry.headDimension)] =
+        entry.strategy
+    }
+    lock.unlock()
+  }
+}
+
+/// A serializable record of calibrated masking-strategy decisions for a set of
+/// shapes on one device.
+///
+/// Produced by `MaskingStrategyHeuristic.calibrate(...)`; consumable by
+/// `MaskingStrategyHeuristic.apply(_:)` and by a separate persistence helper
+/// (`MaskingCalibrationStore`). Callers that don't want to persist can simply
+/// run calibration and let the result be discarded — the in-memory cache is
+/// already populated as a side effect.
+public struct MaskingCalibration: Codable {
+  public struct Entry: Codable {
+    public let sequenceBucket: Int
+    public let headDimension: Int
+    public let strategy: MaskingStrategy
+    /// Measured kernel time (ms) for each strategy; carried as evidence.
+    public let bitmaskMs: Double
+    public let elementWiseMs: Double
+
+    public init(
+      sequenceBucket: Int,
+      headDimension: Int,
+      strategy: MaskingStrategy,
+      bitmaskMs: Double,
+      elementWiseMs: Double
+    ) {
+      self.sequenceBucket = sequenceBucket
+      self.headDimension = headDimension
+      self.strategy = strategy
+      self.bitmaskMs = bitmaskMs
+      self.elementWiseMs = elementWiseMs
+    }
+  }
+
+  public let deviceName: String
+  public let entries: [Entry]
+
+  public init(deviceName: String, entries: [Entry]) {
+    self.deviceName = deviceName
+    self.entries = entries
+  }
+}
+
+public extension MaskingStrategyHeuristic {
+  /// Benchmark bitmask vs element-wise masking for each shape and return a
+  /// `MaskingCalibration` payload. As a side effect, each measured winner is
+  /// recorded into the in-memory cache, so callers who don't care about
+  /// persisting the payload still benefit immediately.
+  ///
+  /// Pass the resulting `MaskingCalibration` to `MaskingCalibrationStore.save`
+  /// if you want to reuse it across runs; otherwise just discard it.
+  ///
+  /// - Parameters:
+  ///   - shapes: `(sequenceLength, headDimension)` pairs to calibrate.
+  ///   - device: Device to benchmark on (defaults to `MTLContext.global`).
+  ///   - warmupIterations: Warmup dispatches before timing (GPU clock ramp).
+  ///   - trialIterations: Timed dispatches; the fastest is kept.
+  func calibrate(
+    shapes: [(sequenceLength: Int, headDimension: Int)],
+    device: MTLDevice? = nil,
+    warmupIterations: Int = 5,
+    trialIterations: Int = 10
+  )
+    -> MaskingCalibration
+  {
+    let dev = device ?? MTLContext.global.device
+    let queue = MTLContext.global.commandQueue
+    var entries: [MaskingCalibration.Entry] = []
+
+    for shape in shapes {
+      let bitmaskMs = timeCausalForward(
+        strategy: .bitmask, sequenceLength: shape.sequenceLength,
+        headDimension: shape.headDimension, device: dev, queue: queue,
+        warmupIterations: warmupIterations, trialIterations: trialIterations
+      )
+      let elementWiseMs = timeCausalForward(
+        strategy: .elementWise, sequenceLength: shape.sequenceLength,
+        headDimension: shape.headDimension, device: dev, queue: queue,
+        warmupIterations: warmupIterations, trialIterations: trialIterations
+      )
+
+      guard let bm = bitmaskMs, let ew = elementWiseMs else {
+        print(
+          "calibrate: skipped seq=\(shape.sequenceLength) head=\(shape.headDimension) (pipeline failure)"
+        )
+        continue
+      }
+      let winner: MaskingStrategy = bm <= ew ? .bitmask : .elementWise
+      entries.append(
+        MaskingCalibration.Entry(
+          sequenceBucket: Self.sequenceBucket(shape.sequenceLength),
+          headDimension: shape.headDimension,
+          strategy: winner,
+          bitmaskMs: bm,
+          elementWiseMs: ew
+        )
+      )
+      recordMeasurement(
+        sequenceLength: shape.sequenceLength,
+        headDimension: shape.headDimension,
+        strategy: winner
+      )
+    }
+
+    return MaskingCalibration(deviceName: dev.name, entries: entries)
+  }
+
+  /// Explicitly warm up the heuristic for a set of shapes, amortizing the
+  /// calibration across runs.
+  ///
+  /// - If `persistTo` points at an existing calibration for this device, it is
+  ///   loaded and applied (cheap — no benchmarking).
+  /// - Otherwise the shapes are benchmarked; if `persistTo` is non-nil the
+  ///   result is saved there for next time.
+  /// - Either way the in-memory cache is populated, so `recommend(...)` is
+  ///   answered from measurement rather than the cold-start rule.
+  ///
+  /// Pass `persistTo: nil` to benchmark for the current process only (the
+  /// "wasteful" path — payload still returned, just not saved).
+  func warmUp(
+    shapes: [(sequenceLength: Int, headDimension: Int)],
+    persistTo url: URL? = nil,
+    device: MTLDevice? = nil,
+    warmupIterations: Int = 5,
+    trialIterations: Int = 10
+  )
+    -> MaskingCalibration
+  {
+    let dev = device ?? MTLContext.global.device
+
+    // Reuse a persisted calibration that matches this device, if present.
+    if
+      let url,
+      let loaded = try? MaskingCalibrationStore.load(from: url),
+      loaded.deviceName == dev.name,
+      !loaded.entries.isEmpty
+    {
+      apply(loaded)
+      return loaded
+    }
+
+    // Otherwise benchmark now and (optionally) persist for next time.
+    let calibration = calibrate(
+      shapes: shapes,
+      device: dev,
+      warmupIterations: warmupIterations,
+      trialIterations: trialIterations
+    )
+    if let url {
+      try? MaskingCalibrationStore.save(calibration, to: url)
+    }
+    return calibration
+  }
+
+  /// Time a causal forward kernel with the given masking strategy forced.
+  /// Returns the fastest trial latency in milliseconds, or nil on pipeline
+  /// failure.
+  private func timeCausalForward(
+    strategy: MaskingStrategy,
+    sequenceLength: Int,
+    headDimension: Int,
+    device: MTLDevice,
+    queue: MTLCommandQueue,
+    warmupIterations: Int,
+    trialIterations: Int
+  )
+    -> Double?
+  {
+    var desc = AttentionDescriptor()
+    desc.lowPrecisionInputs = false
+    desc.matrixDimensions = (
+      row: UInt32(sequenceLength),
+      column: UInt32(sequenceLength),
+      head: UInt16(headDimension)
+    )
+    desc.transposeState = (Q: false, K: false, V: false, O: false)
+    desc.sparsityPattern = .causal
+
+    var kernelDescriptor = desc.kernelDescriptor(type: .forward)
+    kernelDescriptor.maskingStrategyOverride = strategy
+    let kernel = AttentionKernel(descriptor: kernelDescriptor)
+
+    let functionConstants = MTLFunctionConstantValues()
+    desc.setFunctionConstants(functionConstants)
+
+    guard
+      let library = try? device.makeLibrary(source: kernel.createSource(), options: nil),
+      let function = try? library.makeFunction(name: "attention", constantValues: functionConstants)
+    else {
+      return nil
+    }
+    let pipelineDesc = MTLComputePipelineDescriptor()
+    pipelineDesc.computeFunction = function
+    pipelineDesc.maxTotalThreadsPerThreadgroup = 1024
+    guard
+      let pipeline = try? device.makeComputePipelineState(
+        descriptor: pipelineDesc, options: [], reflection: nil
+      )
+    else {
+      return nil
+    }
+
+    // FP32 single-head operands. Small nonzero values (avoid denormals/NaN).
+    let n = sequenceLength * headDimension
+    let fill = Array(repeating: Float(0.01), count: n)
+    let zero = [Float](repeating: 0, count: n)
+    let lzeros = [Float](repeating: 0, count: sequenceLength)
+    guard
+      let q = device.makeBuffer(bytes: fill, length: n * 4, options: .storageModeShared),
+      let k = device.makeBuffer(bytes: fill, length: n * 4, options: .storageModeShared),
+      let v = device.makeBuffer(bytes: fill, length: n * 4, options: .storageModeShared),
+      let o = device.makeBuffer(bytes: zero, length: n * 4, options: .storageModeShared),
+      let l = device.makeBuffer(
+        bytes: lzeros,
+        length: sequenceLength * 4,
+        options: .storageModeShared
+      )
+    else {
+      return nil
+    }
+
+    let parallelization = Int(kernel.blockDimensions.parallelization)
+    let blocks = max(1, (sequenceLength + parallelization - 1) / parallelization)
+    let gridSize = MTLSize(width: blocks, height: 1, depth: 1)
+    let groupSize = MTLSize(width: Int(kernel.threadgroupSize), height: 1, depth: 1)
+    let tgMem = Int(kernel.threadgroupMemoryAllocation)
+
+    func runOnce() -> Double {
+      guard
+        let cb = queue.makeCommandBuffer(),
+        let enc = cb.makeComputeCommandEncoder()
+      else {
+        return .infinity
+      }
+      enc.setComputePipelineState(pipeline)
+      enc.setThreadgroupMemoryLength(tgMem, index: 0)
+      enc.setBuffer(q, offset: 0, index: 0)
+      enc.setBuffer(k, offset: 0, index: 1)
+      enc.setBuffer(v, offset: 0, index: 2)
+      enc.setBuffer(o, offset: 0, index: 3)
+      enc.setBuffer(l, offset: 0, index: 4)
+      enc.dispatchThreadgroups(gridSize, threadsPerThreadgroup: groupSize)
+      enc.endEncoding()
+      cb.commit()
+      cb.waitUntilCompleted()
+      return cb.gpuEndTime - cb.gpuStartTime
+    }
+
+    for _ in 0..<warmupIterations {
+      _ = runOnce()
+    }
+    var best = Double.infinity
+    for _ in 0..<trialIterations {
+      best = min(best, runOnce())
+    }
+    return best.isFinite ? best * 1000.0 : nil
+  }
+}
+
+/// Separate persistence helper for `MaskingCalibration`.
+///
+/// Intentionally decoupled from the heuristic: callers that want to amortize a
+/// calibration across runs write it to disk here and reload it later via
+/// `MaskingStrategyHeuristic.apply(_:)`. Callers that don't care about
+/// persistence never touch this and just use the in-memory cache.
+public enum MaskingCalibrationStore {
+  /// A conventional on-disk location for a device's calibration
+  /// (`~/.cache/<bundle>/masking-calibration/<deviceName>.json`).
+  public static func defaultURL(
+    deviceName: String,
+    bundleIdentifier: String = "FlashAttention"
+  )
+    -> URL
+  {
+    let sanitized = deviceName.replacingOccurrences(of: " ", with: "_")
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    return home
+      .appendingPathComponent(".cache", isDirectory: true)
+      .appendingPathComponent(bundleIdentifier, isDirectory: true)
+      .appendingPathComponent("masking-calibration", isDirectory: true)
+      .appendingPathComponent("\(sanitized).json")
+  }
+
+  /// Encode a calibration to JSON at `url`.
+  public static func save(_ calibration: MaskingCalibration, to url: URL) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(calibration)
+    let dir = url.deletingLastPathComponent()
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try data.write(to: url, options: .atomic)
+  }
+
+  /// Decode a calibration previously written by `save(_:to:)`.
+  public static func load(from url: URL) throws -> MaskingCalibration {
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(MaskingCalibration.self, from: data)
+  }
+}

--- a/Tests/FlashAttentionTests/OurMaskingTest.swift
+++ b/Tests/FlashAttentionTests/OurMaskingTest.swift
@@ -48,40 +48,32 @@ final class OurMaskingTest: XCTestCase {
     print("✅ Custom kernel created")
     print("   Sparsity pattern: custom")
 
-    // Check generated source code
+    // Check generated source code against the ACTUAL codegen markers (the old
+    // "Apply causal masking" / "col_idx > row_idx" strings were removed when
+    // causal masking moved to the bitmask approach — CausalAttentionTest even
+    // asserts those strings are absent).
     print("\n🔍 Checking generated Metal source...")
     let causalSource = causalKernel.createSource()
 
-    if causalSource.contains("Apply causal masking") {
-      print("✅ Causal masking code found in Metal source")
-    } else {
-      print("❌ Causal masking code NOT found in Metal source")
-    }
-
-    if causalSource.contains("col_idx > row_idx") {
-      print("✅ Causal condition found in Metal source")
-    } else {
-      print("❌ Causal condition NOT found in Metal source")
-    }
-
-    print("\n📄 Metal source preview (causal masking section):")
-    let lines = causalSource.components(separatedBy: .newlines)
-    for (i, line) in lines.enumerated() {
-      if line.contains("Apply causal masking") {
-        let start = max(0, i - 2)
-        let end = min(lines.count, i + 10)
-        for j in start..<end {
-          print("   \(j): \(lines[j])")
-        }
-        break
-      }
-    }
+    XCTAssertTrue(causalSource.contains("IS_CAUSAL"), "Causal kernel should reference IS_CAUSAL")
+    XCTAssertTrue(
+      causalSource.contains("causal_mask"),
+      "Causal kernel should generate bitmask causal_mask logic"
+    )
+    // The sparsity-pattern dispatcher must be emitted for a causal descriptor.
+    XCTAssertTrue(
+      causalSource.contains("Apply sparsity patterns"),
+      "Sparsity pattern dispatcher missing"
+    )
+    // And the legacy string-based path must NOT be present.
+    XCTAssertFalse(
+      causalSource.contains("Apply causal masking"),
+      "Legacy causal string should be absent"
+    )
+    print("✅ Causal bitmask codegen verified (IS_CAUSAL, causal_mask)")
 
     print("\n🎯 Summary:")
-    print("   • Masking enum works: ✅")
-    print("   • Descriptor integration works: ✅")
-    print("   • Kernel creation works: ✅")
-    print("   • Metal code generation works: ✅")
-    print("   • Our implementation is CORRECT! 🎉")
+    print("   • Masking enum + descriptor integration: ✅")
+    print("   • Causal Metal codegen verified by assertions: ✅")
   }
 }

--- a/Tests/FlashAttentionTests/WarmupAwarePerformanceTest.swift
+++ b/Tests/FlashAttentionTests/WarmupAwarePerformanceTest.swift
@@ -41,6 +41,108 @@ final class WarmupAwarePerformanceTest: XCTestCase {
     }
   }
 
+  func testCalibrationPayloadRoundTrip() throws {
+    let heuristic = MaskingStrategyHeuristic.shared
+    heuristic.clearCache()
+
+    // Calibrate a couple of small shapes. calibrate() returns a serializable
+    // payload AND populates the in-memory cache as a side effect.
+    let shapes = [
+      (sequenceLength: 256, headDimension: 64),
+      (sequenceLength: 512, headDimension: 128),
+    ]
+    let calibration = heuristic.calibrate(shapes: shapes, warmupIterations: 3, trialIterations: 5)
+
+    XCTAssertEqual(
+      calibration.entries.count,
+      shapes.count,
+      "calibrate should produce one entry per shape"
+    )
+    XCTAssertEqual(calibration.deviceName, MTLContext.global.device.name)
+    print("\n📦 Calibration payload (\(calibration.deviceName)):")
+    for entry in calibration.entries {
+      print(
+        "  seq~\(entry.sequenceBucket), head=\(entry.headDimension): " +
+          "\(entry.strategy == .bitmask ? "BITMASK" : "ELEMENT-WISE") " +
+          "(bitmask \(String(format: "%.3f", entry.bitmaskMs))ms vs " +
+          "element-wise \(String(format: "%.3f", entry.elementWiseMs))ms)"
+      )
+    }
+
+    // Persist to a temp file via the separate store, then load it back and
+    // hydrate a fresh cache. Demonstrates the decoupled persistence: callers
+    // who don't persist just skip this and use the in-memory cache.
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("masking-calibration-test.json")
+    try? FileManager.default.removeItem(at: url)
+    try MaskingCalibrationStore.save(calibration, to: url)
+    let loaded = try MaskingCalibrationStore.load(from: url)
+
+    heuristic.clearCache()
+
+    // After apply(), recommend() must return the measured strategy for each
+    // calibrated shape regardless of the default rule.
+    heuristic.apply(loaded)
+    for (shape, entry) in zip(shapes, loaded.entries) {
+      let recommended = heuristic.recommend(
+        sequenceLength: shape.sequenceLength,
+        headDimension: shape.headDimension
+      )
+      XCTAssertEqual(recommended, entry.strategy, "applied calibration should drive recommend()")
+    }
+
+    try? FileManager.default.removeItem(at: url)
+    print("✅ calibrate → save → load → apply round-trip verified")
+  }
+
+  func testWarmUpAmortizesAcrossRuns() throws {
+    let heuristic = MaskingStrategyHeuristic.shared
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("masking-warmup-test.json")
+    try? FileManager.default.removeItem(at: url)
+
+    let shapes = [(sequenceLength: 256, headDimension: 64)]
+
+    // First warmUp: no persisted file → benchmark, save, apply.
+    heuristic.clearCache()
+    let first = heuristic.warmUp(
+      shapes: shapes,
+      persistTo: url,
+      warmupIterations: 3,
+      trialIterations: 5
+    )
+    XCTAssertFalse(first.entries.isEmpty, "first warmUp should calibrate")
+    XCTAssertTrue(
+      FileManager.default.fileExists(atPath: url.path),
+      "warmUp should persist when given a URL"
+    )
+    let firstStrategy = first.entries[0].strategy
+    XCTAssertEqual(
+      heuristic.recommend(sequenceLength: 256, headDimension: 64), firstStrategy,
+      "warmUp should populate the cache"
+    )
+
+    // Second warmUp: file exists + device matches → load (no benchmark).
+    // Proven by the cache being repopulated after a clear WITHOUT calibrating:
+    // recommend() still returns the persisted strategy.
+    heuristic.clearCache()
+    let second = heuristic.warmUp(
+      shapes: shapes,
+      persistTo: url,
+      warmupIterations: 3,
+      trialIterations: 5
+    )
+    XCTAssertEqual(second.deviceName, first.deviceName)
+    XCTAssertEqual(second.entries[0].strategy, firstStrategy, "loaded calibration should match")
+    XCTAssertEqual(
+      heuristic.recommend(sequenceLength: 256, headDimension: 64), firstStrategy,
+      "loaded calibration should drive recommend()"
+    )
+
+    try? FileManager.default.removeItem(at: url)
+    print("✅ warmUp amortizes: first call calibrated+persisted, second call loaded")
+  }
+
   func testWarmupAwareAutoOptimization() throws {
     print("\n🔥 Warmup-Aware Auto-Optimization Validation")
     print("=" + String(repeating: "=", count: 80))
@@ -351,50 +453,51 @@ final class WarmupAwarePerformanceTest: XCTestCase {
   }
 
   private func testAutoOptimizationDecisions(_ results: [WarmupResult]) {
-    print("\n🤖 Testing Auto-Optimization Decisions")
+    print("\n🤖 Shared heuristic vs. measured (warm)")
     print("-" + String(repeating: "-", count: 60))
 
-    for result in results {
-      // Test our auto-optimization heuristic
-      let totalElements = result.sequenceLength * result.sequenceLength * result.headDimension
-      let shouldUseBitmask = shouldUseBitmaskOptimization(
-        sequenceLength: result.sequenceLength,
-        headDimension: result.headDimension,
-        totalElements: totalElements
-      )
+    // Clear any prior calibration so we measure the DEFAULT rule's accuracy.
+    MaskingStrategyHeuristic.shared.clearCache()
 
-      let actuallyBetter = result.warmSpeedup > 1.0
-      let decision = shouldUseBitmask ? "BITMASK" : "ELEMENT-WISE"
-      let correct = shouldUseBitmask == actuallyBetter
+    var ruleCorrect = 0
+    for result in results {
+      let seq = result.sequenceLength
+      let head = result.headDimension
+      let decision = MaskingStrategyHeuristic.shared.recommend(
+        sequenceLength: seq, headDimension: head
+      )
+      let actuallyBitmask = result.warmSpeedup > 1.0
+      let actual: MaskingStrategy = actuallyBitmask ? .bitmask : .elementWise
+      let correct = (decision == actual)
+      if correct { ruleCorrect += 1 }
 
       print(
-        "seq=\(result.sequenceLength), head=\(result.headDimension): " +
-          "Decision=\(decision), Actually better=\(actuallyBetter ? "BITMASK" : "ELEMENT-WISE") " +
-          "\(correct ? "✅" : "❌")"
+        "seq=\(seq), head=\(head): rule=\(decision == .bitmask ? "BITMASK     " : "ELEMENT-WISE"), " +
+          "measured=\(actual == .bitmask ? "BITMASK     " : "ELEMENT-WISE") " +
+          "(warm \(String(format: "%+.1f%%", result.warmSpeedup * 100 - 100))) \(correct ? "✅" : "❌")"
+      )
+
+      // Feed the warm measurement back into the shared cache so the kernel
+      // and downstream callers see the calibrated truth for this shape.
+      MaskingStrategyHeuristic.shared.recordMeasurement(
+        sequenceLength: seq, headDimension: head, strategy: actual
       )
     }
-  }
 
-  // Copy of the auto-optimization logic from the main implementation
-  private func shouldUseBitmaskOptimization(
-    sequenceLength: Int,
-    headDimension: Int,
-    totalElements: Int
-  )
-    -> Bool
-  {
-    if totalElements < 50_331_648 {
-      return true
+    print(
+      "\nDefault-rule accuracy: \(ruleCorrect)/\(results.count) " +
+        "(\(String(format: "%.0f%%", Double(ruleCorrect) / Double(results.count) * 100)))"
+    )
+
+    // Confirm the cache now reflects the measured truth.
+    var cacheMatches = 0
+    for result in results {
+      let cached = MaskingStrategyHeuristic.shared.recommend(
+        sequenceLength: result.sequenceLength, headDimension: result.headDimension
+      )
+      let actual: MaskingStrategy = result.warmSpeedup > 1.0 ? .bitmask : .elementWise
+      if cached == actual { cacheMatches += 1 }
     }
-
-    if headDimension == 64 || headDimension == 128 {
-      return true
-    }
-
-    if sequenceLength <= 256 {
-      return true
-    }
-
-    return false
+    print("Post-calibration cache accuracy: \(cacheMatches)/\(results.count)")
   }
 }


### PR DESCRIPTION
This pull request introduces enhancements to the masking strategy selection and calibration logic in the FlashAttention codebase. The main focus is on making the masking strategy (bitmask vs. element-wise) more data-driven, configurable, and testable, with improved integration between descriptors, kernels, and the shared heuristic. The changes also update and expand tests to verify the new calibration and persistence mechanisms.

**Masking Strategy Selection and Calibration:**

* Added `sequenceLength` and `maskingStrategyOverride` fields to `AttentionKernelDescriptor` and `AttentionKernel`, allowing explicit control and improved heuristic-based selection of masking strategies. [[1]](diffhunk://#diff-038fb8003657082ad03cdcf16bc3bf7762d6c777a8adf6bc7ba39ab64b9a2670R20-R29) [[2]](diffhunk://#diff-3566e56cab8c6f516ad6145f228fad159fe37f69984fe27270eccfe771cc0c56R28-R31) [[3]](diffhunk://#diff-3566e56cab8c6f516ad6145f228fad159fe37f69984fe27270eccfe771cc0c56R59-R60)
* Updated the masking strategy selection logic in `AttentionKernel+Softmax.swift` to prioritize explicit overrides and use the shared `MaskingStrategyHeuristic` for data-driven decisions, replacing static rules.
* Set `sequenceLength` in the `AttentionDescriptor` output if available, ensuring downstream components have correct context for heuristic selection.

**Testing and Verification:**

* Improved `OurMaskingTest` to assert on the presence of new codegen markers (e.g., `IS_CAUSAL`, `causal_mask`) and absence of legacy string-based masking logic, reflecting the updated code generation path for causal masking.
* Added new tests in `WarmupAwarePerformanceTest` to verify calibration payload round-tripping (serialize, save, load, apply) and that warm-up calibration persists and amortizes across runs.
* Refactored auto-optimization decision tests to compare the shared heuristic’s recommendations against measured performance, update the cache with ground truth, and verify cache accuracy post-calibration.