### PR TITLE
fix output buffer usage (MLA)

### DIFF
--- a/Sources/FlashAttention/Attention/MLAOptimizedGEMMMFA.swift
+++ b/Sources/FlashAttention/Attention/MLAOptimizedGEMMMFA.swift
@@ -181,19 +181,22 @@ public class MLAOptimizedGEMMMFA {
     let totalDim = numHeads * headDim
     let kvSize = batchSize * sequenceLength * totalDim * MemoryLayout<Float16>.size
 
-    // Allocate K,V buffers
-    if self.decompressedK == nil || currentKVSize < kvSize {
-      self.decompressedK = device.makeBuffer(
-        length: kvSize, options: .storageModePrivate
-      )
-      self.decompressedV = device.makeBuffer(
-        length: kvSize, options: .storageModePrivate
-      )
-      currentKVSize = kvSize
+    // Use caller-provided output buffers when supplied (e.g. the FFI bridge,
+    // which backs them with readable MPS/shared-memory tensors). Only allocate
+    // our own private buffers for the Swift-direct path when none are given.
+    if decompressedK == nil || decompressedV == nil {
+      if self.decompressedK == nil || currentKVSize < kvSize {
+        self.decompressedK = device.makeBuffer(
+          length: kvSize, options: .storageModePrivate
+        )
+        self.decompressedV = device.makeBuffer(
+          length: kvSize, options: .storageModePrivate
+        )
+        currentKVSize = kvSize
+      }
+      decompressedK = self.decompressedK
+      decompressedV = self.decompressedV
     }
-
-    decompressedK = self.decompressedK
-    decompressedV = self.decompressedV
 
     guard
       let kBuf = decompressedK,


### PR DESCRIPTION
This pull request updates buffer allocation logic in the `MLAOptimizedGEMMMFA` class to better support interoperability with external callers, such as FFI bridges. Now, the class will use caller-provided output buffers when available, and only allocate its own private buffers when none are supplied. This change improves efficiency and compatibility for different usage scenarios.

**Buffer allocation improvements:**

* Modified the buffer allocation logic in `MLAOptimizedGEMMMFA` to use caller-provided `decompressedK` and `decompressedV` buffers when supplied, allocating private buffers only when they are not provided. This supports FFI bridge scenarios and avoids unnecessary allocations. [[1]](diffhunk://#diff-f2ea6798226050e8a27e0af92a143330ac741eaf81fd2a15319d934d70749ff2L184-R187) [[2]](diffhunk://#diff-f2ea6798226050e8a27e0af92a143330ac741eaf81fd2a15319d934d70749ff2L194-R199)