### PR TITLE
arbitrary masks for quantised attn

### DIFF
--- a/Sources/FlashAttention/Attention/QuantizedAttention.swift
+++ b/Sources/FlashAttention/Attention/QuantizedAttention.swift
@@ -139,7 +139,9 @@ public class QuantizedAttention {
     output: MTLBuffer,
     descriptor: QuantizedAttentionDescriptor,
     bufferOffsets: (q: Int, k: Int, v: Int, o: Int, lse: Int) = (0, 0, 0, 0, 0),
-    externalLogsumexp: MTLBuffer? = nil
+    externalLogsumexp: MTLBuffer? = nil,
+    mask: MTLBuffer? = nil,
+    maskOffset: Int = 0
   )
     -> MTLCommandBuffer?
   {
@@ -231,6 +233,17 @@ public class QuantizedAttention {
       bufferIndex += 1
       encoder.setBuffer(operand.blockZeroPoints, offset: 0, index: bufferIndex)
       bufferIndex += 1
+    }
+
+    // Mask: bound at bufferIndex + 3 (strides) + 4 (multi-head params) = +7.
+    // Strides and multi-head are left nil → kernel uses contiguous/single-head
+    // fallback. The mask buffer is a float32 [S_q, S_kv] additive bias for
+    // the current head.
+    let maskIndex = bufferIndex + 7
+    if let mask {
+      encoder.setBuffer(mask, offset: maskOffset, index: maskIndex)
+    } else {
+      encoder.setBuffer(nil, offset: 0, index: maskIndex)
     }
 
     // Use proper threadgroup configuration from AttentionKernel
@@ -1006,7 +1019,9 @@ extension QuantizedAttention {
     gradQuery: MTLBuffer,
     dValues: MTLBuffer,
     descriptor: QuantizedAttentionDescriptor,
-    bufferOffsets: (q: Int, k: Int, v: Int, o: Int, go: Int, lse: Int, gq: Int, dv: Int) = (0, 0, 0, 0, 0, 0, 0, 0)
+    bufferOffsets: (q: Int, k: Int, v: Int, o: Int, go: Int, lse: Int, gq: Int, dv: Int) = (0, 0, 0, 0, 0, 0, 0, 0),
+    mask: MTLBuffer? = nil,
+    maskOffset: Int = 0
   )
     -> MTLCommandBuffer?
   {
@@ -1062,6 +1077,20 @@ extension QuantizedAttention {
       config: descriptor.quantizationConfig, startingAt: 10
     )
 
+    // Bind mask at the expected buffer slot (after quant params + strides
+    // + multi-head params). bindQuantParams emits 4 values per quantized
+    // operand (scale, zero_point, block_scales, block_zero_points).
+    let numQuant = [descriptor.quantizationConfig.queryPrecision,
+                    descriptor.quantizationConfig.keyPrecision,
+                    descriptor.quantizationConfig.valuePrecision]
+      .filter(\.requiresQuantizationParameters).count
+    let maskIdx = 10 + numQuant * 4 + 7
+    if let mask {
+      encoder.setBuffer(mask, offset: maskOffset, index: maskIdx)
+    } else {
+      encoder.setBuffer(nil, offset: 0, index: maskIdx)
+    }
+
     dispatchBackward(encoder, kernel: core.kernel, parallelizationDim: Int(dims.row))
     encoder.endEncoding()
     return commandBuffer
@@ -1080,7 +1109,9 @@ extension QuantizedAttention {
     gradKey: MTLBuffer,
     gradValue: MTLBuffer,
     descriptor: QuantizedAttentionDescriptor,
-    bufferOffsets: (q: Int, k: Int, v: Int, go: Int, lse: Int, dv: Int, gk: Int, gv: Int) = (0, 0, 0, 0, 0, 0, 0, 0)
+    bufferOffsets: (q: Int, k: Int, v: Int, go: Int, lse: Int, dv: Int, gk: Int, gv: Int) = (0, 0, 0, 0, 0, 0, 0, 0),
+    mask: MTLBuffer? = nil,
+    maskOffset: Int = 0
   )
     -> MTLCommandBuffer?
   {
@@ -1132,6 +1163,17 @@ extension QuantizedAttention {
       encoder, query: query, key: keyBinding, value: valueBinding,
       config: descriptor.quantizationConfig, startingAt: 9
     )
+
+    let numQuantKV = [descriptor.quantizationConfig.queryPrecision,
+                      descriptor.quantizationConfig.keyPrecision,
+                      descriptor.quantizationConfig.valuePrecision]
+      .filter(\.requiresQuantizationParameters).count
+    let maskIdxKV = 9 + numQuantKV * 4 + 7
+    if let mask {
+      encoder.setBuffer(mask, offset: maskOffset, index: maskIdxKV)
+    } else {
+      encoder.setBuffer(nil, offset: 0, index: maskIdxKV)
+    }
 
     dispatchBackward(encoder, kernel: core.kernel, parallelizationDim: Int(dims.row))
     encoder.endEncoding()


### PR DESCRIPTION
This pull request adds support for an optional attention mask buffer to the quantized attention forward and backward passes. The mask is passed as a buffer and bound at the correct index in the Metal encoder, allowing for additive bias masking (such as for causal or padding masks) in the attention computation.

**Attention mask support:**

* Added `mask` and `maskOffset` parameters to the forward and backward pass methods in `QuantizedAttention`, enabling the use of an optional mask buffer in attention computations. [[1]](diffhunk://#diff-3fc5faa720ad86c271440f0ecc853558b8183c2714679efb4f501af8849884ddL142-R144) [[2]](diffhunk://#diff-3fc5faa720ad86c271440f0ecc853558b8183c2714679efb4f501af8849884ddL1009-R1024) [[3]](diffhunk://#diff-3fc5faa720ad86c271440f0ecc853558b8183c2714679efb4f501af8849884ddL1083-R1114)
* Updated the Metal encoder binding logic to bind the mask buffer at the correct slot for both forward and backward passes, ensuring compatibility with quantization parameter layouts. [[1]](diffhunk://#diff-3fc5faa720ad86c271440f0ecc853558b8183c2714679efb4f501af8849884ddR238-R248) [[2]](diffhunk://#diff-3fc5faa720ad86c271440f0ecc853558b8183c2714679efb4f501af8849884ddR1080-R1093) [[3]](diffhunk://#diff-3fc5faa720ad86c271440f0ecc853558b8183c2714679efb4f501af8849884ddR1167-R1177)