### PR TITLE
fix strided reads; fix tuning table for head_dim 128; fix BF16/FP16 native low-precision; fix causal masking (Qwen VL) and a separate transpose bug

### DIFF
--- a/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor+Parameters.swift
+++ b/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor+Parameters.swift
@@ -131,10 +131,13 @@ extension AttentionDescriptor {
   /// If any of the operands is FP16, the parameters will fail to generalize.
   static func forward(device: MTLDevice) -> String {
     if device.supportsFamily(.apple9) {
+      // For head_dim 128, cache one operand only; Q,O spills registers and is much slower.
       """
       | 8   | 16 | 128 | 16 | Q, O |
       | 16  | 16 | 64  | 16 | Q, O |
       | 48  | 16 | 32  | 8  | Q, O |
+      | 127 | 16 | 64  | 16 | O    |
+      | 128 | 32 | 80  | 16 | O    |
       | 192 | 16 | 64  | 16 | O    |
       | 384 | 16 | 128 | 16 |      |
 

--- a/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor+Precisions.swift
+++ b/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor+Precisions.swift
@@ -9,12 +9,13 @@ public extension AttentionDescriptor {
   // This is an expensive computed property. Access it sparingly!
   var memoryPrecisions: [AttentionOperand: GEMMOperandPrecision] {
     var memoryPrecisions: [AttentionOperand: GEMMOperandPrecision] = [:]
+    let resolvedInputPrecision = inputMemoryPrecision ?? .FP16
 
     if lowPrecisionInputs {
-      memoryPrecisions[.Q] = .FP16
-      memoryPrecisions[.K] = .FP16
-      memoryPrecisions[.V] = .FP16
-      memoryPrecisions[.dO] = .BF16
+      memoryPrecisions[.Q] = resolvedInputPrecision
+      memoryPrecisions[.K] = resolvedInputPrecision
+      memoryPrecisions[.V] = resolvedInputPrecision
+      memoryPrecisions[.dO] = resolvedInputPrecision
     } else {
       memoryPrecisions[.Q] = .FP32
       memoryPrecisions[.K] = .FP32
@@ -148,21 +149,23 @@ public extension AttentionDescriptor {
   // This is an expensive computed property. Access it sparingly!
   var registerPrecisions: [AttentionOperand: GEMMOperandPrecision] {
     var registerPrecisions: [AttentionOperand: GEMMOperandPrecision] = [:]
+    let resolvedInputPrecision = inputMemoryPrecision ?? .FP16
 
     // Query whether the hardware fuses the promotion of BF16 to FP32 with
     // the FMA assembly instruction.
     let device = MTLContext.global.device
     let hasNativeBF16Casting = device.supportsFamily(.apple9)
 
-    // BF16 inputs should use FP32 register precision for accumulation to avoid
-    // overflow/underflow in complex attention patterns that stress accumulation precision
+    // BF16 softmax/backward accumulators stay FP32; Q/K/V can remain BF16 on
+    // Apple9 because the matrix multiply intrinsic accumulates into FP32.
     let forceFP32AccumulationForBF16 = true
 
     // Inputs have the same register precision across kernels.
     if lowPrecisionInputs {
-      registerPrecisions[.Q] = .FP16
-      registerPrecisions[.K] = .FP16
-      registerPrecisions[.V] = .FP16
+      let inputRegisterPrecision: GEMMOperandPrecision = resolvedInputPrecision == .BF16 ? .BF16 : .FP16
+      registerPrecisions[.Q] = inputRegisterPrecision
+      registerPrecisions[.K] = inputRegisterPrecision
+      registerPrecisions[.V] = inputRegisterPrecision
       // Always use FP32 for BF16 dO register precision to prevent accumulation NaNs
       registerPrecisions[.dO] = (hasNativeBF16Casting && !forceFP32AccumulationForBF16) ? .BF16 :
         .FP32
@@ -202,7 +205,7 @@ public extension AttentionDescriptor {
       // FP16 (Q, K, S) | 5e-2
       // FP16 (P)       | 2.7e-3
       // BF16 (dS)      | 8e-3
-      registerPrecisions[.S] = lowPrecisionInputs ? .FP16 : .FP32
+      registerPrecisions[.S] = lowPrecisionInputs && resolvedInputPrecision == .FP16 ? .FP16 : .FP32
       registerPrecisions[.P] = .FP16
       registerPrecisions[.dP] = .FP32
       // Always use FP32 for BF16 dS register precision to prevent accumulation NaNs

--- a/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor.swift
+++ b/Sources/FlashAttention/Attention/AttentionDescriptor/AttentionDescriptor.swift
@@ -17,6 +17,7 @@ public enum SparsityPattern {
 public struct AttentionDescriptor {
   // Q, K, V, dO
   public var lowPrecisionInputs: Bool = false
+  public var inputMemoryPrecision: GEMMOperandPrecision?
 
   // S, P, L, D, dP, dS
   public var lowPrecisionIntermediates: Bool = false

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+Softmax.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+Softmax.swift
@@ -512,11 +512,15 @@ extension AttentionKernel {
 
               // Optimized causal masking using bitmask approach (transposed)
               if (IS_CAUSAL) {
-                // Pre-compute causal mask for 2-element vector
-                uint causal_mask = 0;
-                if (col_idx >= row_base) {
-                  uint mask_width = min(2u, col_idx - row_base + 1);
-                  causal_mask = (1u << mask_width) - 1;
+                // Transposed tile: row_idx is the Q position, col_idx the KV
+                // position. Causal keeps q_row >= kv_col, so element `index`
+                // is kept iff row_base + index >= col_idx. (The previous
+                // formula kept the inverted triangle, corrupting dK/dV for
+                // every shape whose heuristic picked the bitmask path.)
+                uint causal_mask = 0b11;
+                if (col_idx > row_base) {
+                  uint shift = col_idx - row_base;
+                  causal_mask = (shift >= 2) ? 0u : ((0b11u << shift) & 0b11u);
                 }
 
                 #pragma clang loop unroll(full)

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+Source.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel+Source.swift
@@ -43,6 +43,16 @@ public extension AttentionKernel {
     ) {
       ushort2 morton_offset = morton_order(lane_id);
 
+      // Runtime leading dimensions for device-memory tiles of Q/K/V.
+      // With stride buffers bound (ELEMENT strides, BHSD order), rows
+      // within a head are strides[2] elements apart; the last dim must be
+      // contiguous. Without strides the tensors are contiguous and the
+      // leading dimension is the head dimension.
+      uint Q_ld = (Q_strides != nullptr) ? uint(Q_strides[2]) : \(headDimension);
+      uint K_ld = (K_strides != nullptr) ? uint(K_strides[2]) : \(headDimension);
+      uint V_ld = (V_strides != nullptr) ? uint(V_strides[2]) : \(headDimension);
+      (void)Q_ld; (void)K_ld; (void)V_ld;
+
       // Extract dimensions from 3D grid position
       uint block_id = gid.x;    // Sequence block index
       uint head_id = gid.y;     // Head index
@@ -80,25 +90,35 @@ public extension AttentionKernel {
         // Check if stride information is provided for non-contiguous tensor support
         uint q_batch_head_offset = 0;
         uint kv_batch_head_offset = 0;
+        uint v_batch_head_offset = 0;
         uint o_batch_head_offset = 0;
 
         if (Q_strides != nullptr) {
-          // Use stride-based offset calculation for non-contiguous tensors
-          // Assuming 4D tensor layout: [batch, seq, heads, dim] or [batch, heads, seq, dim]
-          // Strides tell us how to calculate the actual memory offset
-          q_batch_head_offset = batch_id * Q_strides[0] + head_id * Q_strides[2];
+          // Stride-based offsets for non-contiguous tensors. Strides are
+          // ELEMENT strides in BHSD order: [batch, head, seq, dim]. The
+          // last dim must be contiguous (stride 1); the seq stride feeds
+          // tile addressing via the runtime leading dimension below.
+          q_batch_head_offset = batch_id * uint(Q_strides[0]) + head_id * uint(Q_strides[1]);
         } else {
           // Fallback to contiguous layout assumption
           q_batch_head_offset = (batch_id * num_heads + head_id) * sequence_length * head_dimension;
         }
 
-        if (K_strides != nullptr && V_strides != nullptr) {
-          kv_batch_head_offset = batch_id * K_strides[0] + kv_head_id * K_strides[2];
+        if (K_strides != nullptr) {
+          kv_batch_head_offset = batch_id * uint(K_strides[0]) + kv_head_id * uint(K_strides[1]);
         } else {
           kv_batch_head_offset = (batch_id * num_kv_heads + kv_head_id) * sequence_length * head_dimension;
         }
 
-        o_batch_head_offset = q_batch_head_offset;  // Output has same shape as query
+        if (V_strides != nullptr) {
+          v_batch_head_offset = batch_id * uint(V_strides[0]) + kv_head_id * uint(V_strides[1]);
+        } else {
+          v_batch_head_offset = (batch_id * num_kv_heads + kv_head_id) * sequence_length * head_dimension;
+        }
+
+        // O is always a dense contiguous allocation (the host allocates it),
+        // even when Q is a strided view — never reuse Q's strided offset.
+        o_batch_head_offset = (batch_id * num_heads + head_id) * sequence_length * head_dimension;
 
         // Apply offsets to buffer pointers based on kernel type
         // Only apply offsets if we have multiple heads or batches
@@ -136,7 +156,7 @@ extension AttentionKernel {
       """
       Q = Q + q_batch_head_offset;
       K = K + kv_batch_head_offset;
-      V = V + kv_batch_head_offset;
+      V = V + v_batch_head_offset;
       O = O + o_batch_head_offset;
       L = L + (batch_id * num_heads + head_id) * sequence_length;
       """
@@ -144,7 +164,7 @@ extension AttentionKernel {
       """
       Q = Q + q_batch_head_offset;
       K = K + kv_batch_head_offset;
-      V = V + kv_batch_head_offset;
+      V = V + v_batch_head_offset;
       O = O + o_batch_head_offset;
       dO = dO + o_batch_head_offset;
       dQ = dQ + q_batch_head_offset;
@@ -158,7 +178,7 @@ extension AttentionKernel {
       """
       Q = Q + q_batch_head_offset;
       K = K + kv_batch_head_offset;
-      V = V + kv_batch_head_offset;
+      V = V + v_batch_head_offset;
       dO = dO + o_batch_head_offset;
       dV = dV + kv_batch_head_offset;
       dK = dK + kv_batch_head_offset;

--- a/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel.swift
+++ b/Sources/FlashAttention/Attention/AttentionKernel/AttentionKernel.swift
@@ -298,9 +298,17 @@ extension AttentionKernel {
 
   func leadingDimension(_ operand: AttentionOperand) -> String {
     if transposed(operand) {
-      sequenceLength(operand)
-    } else {
-      "\(headDimension)"
+      return sequenceLength(operand)
+    }
+    // Q/K/V device tiles use runtime leading dimensions (declared at the top
+    // of the kernel body) so strided views — rows strides[2] elements apart,
+    // contiguous last dim — address correctly. All other operands (O, dO,
+    // dQ, ...) are dense host allocations with leading dimension = head dim.
+    switch operand {
+    case .Q: return "Q_ld"
+    case .K: return "K_ld"
+    case .V: return "V_ld"
+    default: return "\(headDimension)"
     }
   }
 

--- a/Sources/FlashAttention/Attention/MultiHeadAttention.swift
+++ b/Sources/FlashAttention/Attention/MultiHeadAttention.swift
@@ -190,6 +190,49 @@ public class MultiHeadAttention {
     return commandBuffer
   }
 
+  /// Encode the forward pass into a caller-provided command buffer without
+  /// committing it. This lets the host integrate attention into an external
+  /// stream (e.g. PyTorch's MPS stream) so no cross-queue synchronization is
+  /// needed around the dispatch. Buffer offsets are in bytes.
+  public func encodeForward(
+    commandBuffer: MTLCommandBuffer,
+    query: MTLBuffer,
+    key: MTLBuffer,
+    value: MTLBuffer,
+    output: MTLBuffer,
+    queryOffset: Int = 0,
+    keyOffset: Int = 0,
+    valueOffset: Int = 0,
+    outputOffset: Int = 0,
+    queryStrides: [Int64]? = nil,
+    keyStrides: [Int64]? = nil,
+    valueStrides: [Int64]? = nil,
+    logsumexp: MTLBuffer? = nil,
+    descriptor: MultiHeadAttentionDescriptor,
+    maskBuffer: MTLBuffer? = nil
+  )
+    -> Bool
+  {
+    var resolvedDescriptor = descriptor
+    if var sparseMask = resolvedDescriptor.baseDescriptor.sparseMask {
+      sparseMask.isMQA = resolvedDescriptor.broadcastMode.isMultiQuery
+      sparseMask.numKVHeads = resolvedDescriptor.keyShape.numHeads
+      resolvedDescriptor.baseDescriptor.sparseMask = sparseMask
+    }
+    let resolvedMaskBuffer = maskBuffer ?? resolvedDescriptor.baseDescriptor.sparseMask?.maskBuffer
+
+    return dispatchBatched(
+      commandBuffer: commandBuffer,
+      query: query, key: key, value: value, output: output,
+      queryOffset: queryOffset, keyOffset: keyOffset,
+      valueOffset: valueOffset, outputOffset: outputOffset,
+      queryStrides: queryStrides, keyStrides: keyStrides,
+      valueStrides: valueStrides,
+      logsumexp: logsumexp, descriptor: resolvedDescriptor,
+      maskBuffer: resolvedMaskBuffer
+    ) != nil
+  }
+
   /// Dispatch strategy: unified dispatch with all batches and heads in parallel
   private func dispatchPerBatch(
     commandBuffer: MTLCommandBuffer,
@@ -212,6 +255,8 @@ public class MultiHeadAttention {
   private func dispatchBatched(
     commandBuffer: MTLCommandBuffer,
     query: MTLBuffer, key: MTLBuffer, value: MTLBuffer, output: MTLBuffer,
+    queryOffset: Int = 0, keyOffset: Int = 0, valueOffset: Int = 0, outputOffset: Int = 0,
+    queryStrides: [Int64]? = nil, keyStrides: [Int64]? = nil, valueStrides: [Int64]? = nil,
     logsumexp: MTLBuffer?, descriptor: MultiHeadAttentionDescriptor,
     maskBuffer: MTLBuffer?
   )
@@ -240,10 +285,10 @@ public class MultiHeadAttention {
     // (see AttentionKernel.createBufferBindings): Q@0 K@1 V@2 O@3 L@4,
     // then (for non-quantized kernels) Q_strides@5 K_strides@6 V_strides@7,
     // then num_heads@8 num_kv_heads@9 head_dim@10 seq@11, then mask@12.
-    encoder.setBuffer(query, offset: 0, index: 0)
-    encoder.setBuffer(key, offset: 0, index: 1)
-    encoder.setBuffer(value, offset: 0, index: 2)
-    encoder.setBuffer(output, offset: 0, index: 3)
+    encoder.setBuffer(query, offset: queryOffset, index: 0)
+    encoder.setBuffer(key, offset: keyOffset, index: 1)
+    encoder.setBuffer(value, offset: valueOffset, index: 2)
+    encoder.setBuffer(output, offset: outputOffset, index: 3)
 
     // The kernel always writes L (logsumexp). Provide a scratch buffer for
     // forward-only calls that pass logsumexp=nil, otherwise the kernel writes
@@ -273,14 +318,22 @@ public class MultiHeadAttention {
     }
     encoder.setBuffer(lBuffer, offset: 0, index: 4)
 
-    // Strides @5/6/7: bind nil so the kernel uses its contiguous-fallback
-    // offset math (batch*num_heads + head) * seq * dim, which matches the
-    // contiguous BHSD layout the host now passes. (The kernel's stride-index
-    // path reads head stride from the wrong array slot; the contiguous path
-    // is correct, so disable the stride path by passing null.)
-    encoder.setBuffer(nil, offset: 0, index: 5)
-    encoder.setBuffer(nil, offset: 0, index: 6)
-    encoder.setBuffer(nil, offset: 0, index: 7)
+    // Strides @5/6/7: ELEMENT strides in BHSD order, last dim must be
+    // contiguous (stride 1). When nil, the kernel uses its contiguous
+    // offset math (batch*num_heads + head) * seq * dim and a leading
+    // dimension equal to the head dimension.
+    let strideBindings: [(Int, [Int64]?)] = [
+      (5, queryStrides), (6, keyStrides), (7, valueStrides),
+    ]
+    for (index, strides) in strideBindings {
+      if let strides, strides.count == 4 {
+        strides.withUnsafeBytes { raw in
+          encoder.setBytes(raw.baseAddress!, length: raw.count, index: index)
+        }
+      } else {
+        encoder.setBuffer(nil, offset: 0, index: index)
+      }
+    }
 
     // Multi-head parameters @8..11
     var numHeads = descriptor.queryShape.numHeads
@@ -378,7 +431,23 @@ public class MultiHeadAttention {
     -> MTLComputePipelineState?
   {
     let source = kernel.createSource()
-    let cacheKey = String(source.hashValue)
+    // The compiled pipeline bakes in function constants (matrix dimensions,
+    // causal flag, window size) that are NOT part of the generated source —
+    // the source is dimension-generic. Keying by source hash alone returns a
+    // pipeline compiled for a DIFFERENT shape whenever two shapes share
+    // codegen, which corrupts memory (the kernel runs with the wrong baked-in
+    // row/column dimensions). Include every setFunctionConstants input in
+    // the key.
+    let base = descriptor.baseDescriptor
+    let dims = base.matrixDimensions.map { "\($0.row)x\($0.column)x\($0.head)" } ?? "nil"
+    var sparsity = "none"
+    switch base.sparsityPattern {
+    case .none: sparsity = "none"
+    case .causal: sparsity = "causal"
+    case let .slidingWindow(size): sparsity = "window\(size)"
+    case .custom: sparsity = "custom"
+    }
+    let cacheKey = "\(source.hashValue)_\(dims)_\(sparsity)"
 
     if let cached = pipelineCache[cacheKey] {
       return cached


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the FlashAttention implementation, focusing on enhanced support for non-contiguous (strided) tensor layouts, improved precision handling, and critical bug fixes for causal masking and kernel pipeline caching. These changes increase the flexibility, correctness, and integration capabilities of the attention kernels, especially when interoperating with frameworks like PyTorch.

**Support for Non-Contiguous Tensor Layouts**

* The attention kernels now properly handle strided (non-contiguous) tensor layouts for Q, K, and V by using runtime-calculated leading dimensions and correct offset calculations based on provided strides. This allows the kernels to operate on views and tensors with arbitrary memory layouts, not just contiguous allocations. (`AttentionKernel+Source.swift`, `AttentionKernel.swift`) [[1]](diffhunk://#diff-62a8daed7abd7f2aa82270c641d1723b22ca0f710558fbe967a1dde1d395d705R46-R55) [[2]](diffhunk://#diff-62a8daed7abd7f2aa82270c641d1723b22ca0f710558fbe967a1dde1d395d705R93-R121) [[3]](diffhunk://#diff-62a8daed7abd7f2aa82270c641d1723b22ca0f710558fbe967a1dde1d395d705L139-R167) [[4]](diffhunk://#diff-62a8daed7abd7f2aa82270c641d1723b22ca0f710558fbe967a1dde1d395d705L161-R181) [[5]](diffhunk://#diff-3566e56cab8c6f516ad6145f228fad159fe37f69984fe27270eccfe771cc0c56L301-R311)
* The `MultiHeadAttention` API and kernel dispatch now accept optional stride arrays for Q, K, and V, passing them to the kernel and binding them as function arguments. (`MultiHeadAttention.swift`) [[1]](diffhunk://#diff-54b2e71c18d1fa9a85f3a7d7cd1aabdaaa23bc7badb29010db3dd16b9e83ef36R193-R235) [[2]](diffhunk://#diff-54b2e71c18d1fa9a85f3a7d7cd1aabdaaa23bc7badb29010db3dd16b9e83ef36R258-R259) [[3]](diffhunk://#diff-54b2e71c18d1fa9a85f3a7d7cd1aabdaaa23bc7badb29010db3dd16b9e83ef36L243-R291) [[4]](diffhunk://#diff-54b2e71c18d1fa9a85f3a7d7cd1aabdaaa23bc7badb29010db3dd16b9e83ef36L276-R336)

**Precision Handling Improvements**

* The `AttentionDescriptor` now supports an optional `inputMemoryPrecision` property, allowing the user to specify the precision (FP16/BF16) for memory and register usage. The precision logic for both memory and register allocations is updated to respect this setting, providing more control and correctness for mixed-precision scenarios. (`AttentionDescriptor.swift`, `AttentionDescriptor+Precisions.swift`) [[1]](diffhunk://#diff-5b4bce5527686f87c4dd1cba46fd379dce838f970d27ce0e08216f63001db9b2R20) [[2]](diffhunk://#diff-0903525d8c06b09ab3229807d347ff7484a586c2261e01db22232d3a69cb7546R12-R18) [[3]](diffhunk://#diff-0903525d8c06b09ab3229807d347ff7484a586c2261e01db22232d3a69cb7546R152-R168) [[4]](diffhunk://#diff-0903525d8c06b09ab3229807d347ff7484a586c2261e01db22232d3a69cb7546L205-R208)

**Bug Fixes and Correctness**

* The causal masking logic in the softmax kernel is fixed to correctly handle the transposed tile case, ensuring that gradients for dK/dV are not corrupted in causal attention. (`AttentionKernel+Softmax.swift`)
* The kernel pipeline cache key now includes all function constant inputs (dimensions, sparsity, etc.), preventing mismatches that could lead to incorrect kernel execution with the wrong baked-in parameters. (`MultiHeadAttention.swift`)

**Heuristic and Documentation Updates**

* Heuristics for register caching are updated for specific head dimensions, and comments are clarified to reflect the new logic and improve maintainability. (`AttentionDescriptor+Parameters.swift`)

These changes collectively improve the robustness, flexibility, and correctness of the FlashAttention implementation, especially in advanced or framework-integrated use cases.